### PR TITLE
Add region information when querying volumes

### DIFF
--- a/automatic-snapshot-script.sh
+++ b/automatic-snapshot-script.sh
@@ -102,7 +102,7 @@ log_setup
 prerequisite_check
 
 # Grab all volume IDs attached to this instance
-volume_list=$(aws ec2 describe-volumes --query Volumes[].VolumeId --output text)
+volume_list=$(aws ec2 describe-volumes --region $region --query Volumes[].VolumeId --output text)
 
 snapshot_volumes
 cleanup_snapshots


### PR DESCRIPTION
currently there are a few cases where the aws cli complains because no region was passed to it. In my case, this happens even though I have configured the aws cli with my default region.